### PR TITLE
Update section on embed ipywidgets

### DIFF
--- a/docs/template_usage.rst
+++ b/docs/template_usage.rst
@@ -168,14 +168,7 @@ Any ipywidget can be embedded by setting them in a trait and adding widget_seria
 
     class MyComponent(v.VuetifyTemplate):
 
-        items = traitlets.List([{
-            'title': 'Title 1',
-            'content': slider1
-        }, {
-            'title': 'Title 2',
-            'content': slider2
-        }]).tag(sync=True, **widgets.widget_serialization)
-
+        items = traitlets.List().tag(sync=True, **widgets.widget_serialization)
         single_widget = traitlets.Any().tag(sync=True, **widgets.widget_serialization)
     
         def __init__(self, description='Single slider', value=40, **kwargs):
@@ -199,4 +192,13 @@ Any ipywidget can be embedded by setting them in a trait and adding widget_seria
             </template>
             '''
 
-    MyComponent()
+    MyComponent(
+        items=[{
+            'title': 'Title 1',
+            'content': slider1
+        }, {
+            'title': 'Title 2',
+            'content': slider2
+        }],
+        single_widget=widgets.IntSlider(description='Single slider', value=40))
+    )

--- a/docs/template_usage.rst
+++ b/docs/template_usage.rst
@@ -170,14 +170,6 @@ Any ipywidget can be embedded by setting them in a trait and adding widget_seria
 
         items = traitlets.List().tag(sync=True, **widgets.widget_serialization)
         single_widget = traitlets.Any().tag(sync=True, **widgets.widget_serialization)
-    
-        def __init__(self, description='Single slider', value=40, **kwargs):
-            self.single_widget = widgets.IntSlider(
-                description=description, 
-                value=value, 
-                **kwargs
-            )
-            super().__init__()        
 
         @traitlets.default('template')
         def _template(self):

--- a/docs/template_usage.rst
+++ b/docs/template_usage.rst
@@ -178,9 +178,12 @@ Any ipywidget can be embedded by setting them in a trait and adding widget_seria
 
         single_widget = traitlets.Any().tag(sync=True, **widgets.widget_serialization)
     
-        def __init__(self, **kwargs):
-            self.single_widget = widgets.IntSlider(description='Single slider', value=40)
-            self.single_widget.__init__(**kwargs)
+        def __init__(self, description='Single slider', value=40, **kwargs):
+            self.single_widget = widgets.IntSlider(
+                description=description, 
+                value=value, 
+                **kwargs
+            )
             super().__init__()        
 
         @traitlets.default('template')

--- a/docs/template_usage.rst
+++ b/docs/template_usage.rst
@@ -155,7 +155,7 @@ A demonstration in a screen capture:
 Embed ipywidgets
 ----------------
 
-Other ipywidgets can be embedded by setting them in a trait and adding widget_serialization, accessing them in the with the `jupyter-widget` tag:
+Any ipywidget can be embedded by setting them in a trait and adding widget_serialization, accessing them in the template with the `jupyter-widget` tag:
 
 .. code-block:: python
 
@@ -164,7 +164,7 @@ Other ipywidgets can be embedded by setting them in a trait and adding widget_se
     import traitlets
 
     slider1 = widgets.IntSlider(description='Slider 1', value=20)
-    slider2 = v.Slider(label="Slider 2", v_model="8")
+    slider2 = v.Slider(label='Slider 2', v_model=8)
 
     class MyComponent(v.VuetifyTemplate):
 
@@ -176,13 +176,16 @@ Other ipywidgets can be embedded by setting them in a trait and adding widget_se
             'content': slider2
         }]).tag(sync=True, **widgets.widget_serialization)
 
-        single_widget = traitlets.Any(
-            widgets.IntSlider(description='Single slider', value=40)
-        ).tag(sync=True, **widgets.widget_serialization)
+        single_widget = traitlets.Any().tag(sync=True, **widgets.widget_serialization)
+    
+        def __init__(self, **kwargs):
+            self.single_widget = widgets.IntSlider(description='Single slider', value=40)
+            self.single_widget.__init__(**kwargs)
+            super().__init__()        
 
         @traitlets.default('template')
         def _template(self):
-            return """
+            return '''
             <template>
                 <div>
                     <div v-for="item in items" :key="item.title + item.content">
@@ -191,6 +194,6 @@ Other ipywidgets can be embedded by setting them in a trait and adding widget_se
                     Single widget: <jupyter-widget :widget="single_widget" />
                 </div>
             </template>
-            """
+            '''
 
     MyComponent()

--- a/docs/template_usage.rst
+++ b/docs/template_usage.rst
@@ -155,7 +155,7 @@ A demonstration in a screen capture:
 Embed ipywidgets
 ----------------
 
-Any ipywidget can be embedded by setting them in a trait and adding widget_serialization, accessing them in the template with the `jupyter-widget` tag:
+Any ipywidget can be embedded by setting them in a trait and adding widget_serialization, accessing them in the template with the ``jupyter-widget`` tag:
 
 .. code-block:: python
 


### PR DESCRIPTION
In the current example, `single_widget` is only a class attribute, such that when creating a new instance of `MyComponent`, the same widget is displayed. The user rather would rather need to have a different instance of `single_widget` for each instance of `MyComponent`.

For that, I suggest to initialise the embedded ipywidget of `MyComponent` within the `__init__` function. This also gives the possibility of customising the embedded widget upon instantiating `MyComponent`, via keyword arguments given to the `_init__` function.

The patch also harmonises quote style used in the code example.