### PR TITLE
fix: create new app when vuetify view is child of a widget for nodeps (Solara and Voila)

### DIFF
--- a/js/src/nodepsVuetifyView.js
+++ b/js/src/nodepsVuetifyView.js
@@ -2,14 +2,41 @@ import { DOMWidgetView } from "@jupyter-widgets/base";
 import { vueRender, createViewContext } from "jupyter-vue";
 
 export class VuetifyView extends DOMWidgetView {
-  vueRender(createElement) {
-    return createElement({
-      provide: {
-        viewCtx: createViewContext(this),
-      },
-      render: () => {
-        return vueRender(createElement, this.model, this);
-      },
-    });
-  }
+    remove() {
+        if(this.vueApp) {
+            this.vueApp.$destroy();
+        }
+        return super.remove();
+    }
+
+    render() {
+        super.render();
+        this.displayed.then(() => {
+            const vueEl = document.createElement('div');
+            this.el.appendChild(vueEl);
+            const view = this;
+
+            this.vueApp = new Vue({
+                // TODO: should we pass in vuetify here?
+                el: vueEl,
+                provide: {
+                    viewCtx: createViewContext(this),
+                },
+                render(createElement) {
+                    return view.vueRender(createElement);
+                },
+            });
+        });
+    }
+
+    vueRender(createElement) {
+        return createElement({
+          provide: {
+            viewCtx: createViewContext(this),
+          },
+          render: () => {
+            return vueRender(createElement, this.model, this);
+          },
+        });
+    }
 }

--- a/js/src/nodepsVuetifyView.js
+++ b/js/src/nodepsVuetifyView.js
@@ -1,5 +1,6 @@
 import { DOMWidgetView } from "@jupyter-widgets/base";
 import { vueRender, createViewContext } from "jupyter-vue";
+import vuetify from "./plugins/nodepsVuetify";
 
 export class VuetifyView extends DOMWidgetView {
     remove() {
@@ -17,7 +18,7 @@ export class VuetifyView extends DOMWidgetView {
             const view = this;
 
             this.vueApp = new Vue({
-                // TODO: should we pass in vuetify here?
+                vuetify,
                 el: vueEl,
                 provide: {
                     viewCtx: createViewContext(this),

--- a/js/src/nodepsVuetifyView.js
+++ b/js/src/nodepsVuetifyView.js
@@ -3,51 +3,47 @@ import { vueRender, createViewContext } from "jupyter-vue";
 import vuetify from "./plugins/nodepsVuetify";
 
 export class VuetifyView extends DOMWidgetView {
-    remove() {
-        if(this.vueApp) {
-            this.vueApp.$destroy();
-        }
-        return super.remove();
+  remove() {
+    if (this.vueApp) {
+      this.vueApp.$destroy();
     }
+    return super.remove();
+  }
 
-    render() {
-        super.render();
-        this.displayed.then(() => {
-            const vueEl = document.createElement('div');
-            this.el.appendChild(vueEl);
-            const view = this;
+  render() {
+    super.render();
+    this.displayed.then(() => {
+      const vueEl = document.createElement("div");
+      this.el.appendChild(vueEl);
+      const view = this;
 
-            this.vueApp = new Vue({
-                vuetify,
-                el: vueEl,
-                provide: {
-                    viewCtx: createViewContext(this),
-                },
-                render(createElement) {
-                    // see VuetifyView.js
-                    if (!view.ipyvuetifyApp) {
-                        view.ipyvuetifyApp =
-                            createElement("v-app", [
-                                vueRender(createElement, view.model, view),
-                            ]);
-                    }
-                    return view.ipyvuetifyApp;
-                },
-            });
-        });
-    }
+      this.vueApp = new Vue({
+        vuetify,
+        el: vueEl,
+        provide: {
+          viewCtx: createViewContext(this),
+        },
+        render(createElement) {
+          // see VuetifyView.js
+          if (!view.ipyvuetifyApp) {
+            view.ipyvuetifyApp = createElement("v-app", [
+              vueRender(createElement, view.model, view),
+            ]);
+          }
+          return view.ipyvuetifyApp;
+        },
+      });
+    });
+  }
 
-
-    vueRender(createElement) {
-       return createElement({
-          provide: {
-            viewCtx: createViewContext(this),
-          },
-          render: () => {
-            return vueRender(createElement, this.model, this);
-          },
-        });
-    }
+  vueRender(createElement) {
+    return createElement({
+      provide: {
+        viewCtx: createViewContext(this),
+      },
+      render: () => {
+        return vueRender(createElement, this.model, this);
+      },
+    });
+  }
 }
-
-

--- a/js/src/nodepsVuetifyView.js
+++ b/js/src/nodepsVuetifyView.js
@@ -24,14 +24,22 @@ export class VuetifyView extends DOMWidgetView {
                     viewCtx: createViewContext(this),
                 },
                 render(createElement) {
-                    return view.vueRender(createElement);
+                    // see VuetifyView.js
+                    if (!view.ipyvuetifyApp) {
+                        view.ipyvuetifyApp =
+                            createElement("v-app", [
+                                vueRender(createElement, view.model, view),
+                            ]);
+                    }
+                    return view.ipyvuetifyApp;
                 },
             });
         });
     }
 
+
     vueRender(createElement) {
-        return createElement({
+       return createElement({
           provide: {
             viewCtx: createViewContext(this),
           },
@@ -41,3 +49,5 @@ export class VuetifyView extends DOMWidgetView {
         });
     }
 }
+
+

--- a/js/src/plugins/nodepsVuetify.js
+++ b/js/src/plugins/nodepsVuetify.js
@@ -4,6 +4,6 @@
  * until all users have upgraded to Voila-vuetify > 0.2.2 and voila-embed > 2020-02-11, or
  * ipyvuetify bumps a major version */
 const vuetify = window.app &&
-  window.app.$vuetify && { framework: window.app.$vuetify };
+  window.app.$vuetify && window.app.$options.vuetify;
 
 export default vuetify;


### PR DESCRIPTION
Previously, when we had a vue->widget->vue tree outside of the notebook context (in Voila or Solara), we would not create a new Vue app. The widget would render as an empty div, and the vue app would not be used at all.

A bit unsure if we should pass in vuetify, like in the normal VuetifyView. But if I passed it in, I got an error in the js console: