### PR TITLE
fix: install is broken due to pyproject.toml being present

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,32 +8,59 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
-
     steps:
       - uses: actions/checkout@v2
+
       - name: Install node
         uses: actions/setup-node@v1
         with:
           node-version: "14.x"
           registry-url: "https://registry.npmjs.org"
+
       - name: Install Python
         uses: actions/setup-python@v2
         with:
           python-version: "3.x"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install twine wheel jupyter-packaging jupyterlab
+
       - name: Build
         run: |
           python setup.py generate_source
-          python setup.py bdist_wheel
+          python setup.py sdist bdist_wheel
+
+      - name: Upload builds
+        uses: actions/upload-artifact@v3
+        with:
+          name: ipyvuetify-dist-${{ github.run_number }}
+          path: ./dist
+
+  test:
+    needs: [build]
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: ipyvuetify-dist-${{ github.run_number }}
+          path: ./dist
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Install
         run: pip install dist/*.whl
+
       - name: Import
         # do the import in a subdirectory, as after installation, files in de current directory are also imported
         run: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ recursive-include ipyvuetify/nbextension *.*
 recursive-include ipyvuetify/labextension *.*
 include jupyter-vuetify.json
 recursive-include ipyvuetify/extra *.vue
+recursive-include generate_source/ *.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["jupyter_packaging~=0.7.9", "jupyterlab~=3.0", "setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [tool.ruff]
 exclude = [
     '.git',

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,24 @@ npm_path = os.pathsep.join(
 LONG_DESCRIPTION = "Jupyter widgets based on vuetify UI components"
 
 
+def get_data_files():
+    return [
+        (
+            "share/jupyter/nbextensions/jupyter-vuetify",
+            glob.glob("ipyvuetify/nbextension/*"),
+        ),
+        (
+            "share/jupyter/labextensions/jupyter-vuetify",
+            glob.glob("ipyvuetify/labextension/package.json"),
+        ),
+        (
+            "share/jupyter/labextensions/jupyter-vuetify/static",
+            glob.glob("ipyvuetify/labextension/static/*"),
+        ),
+        ("etc/jupyter/nbconfig/notebook.d", ["jupyter-vuetify.json"]),
+    ]
+
+
 def js_prerelease(command, strict=False):
     """decorator for building minified js/css prior to another command"""
 
@@ -60,7 +78,7 @@ def js_prerelease(command, strict=False):
 def update_package_data(distribution):
     """update package_data to catch changes during setup"""
     build_py = distribution.get_command_obj("build_py")
-    # distribution.package_data = find_package_data()
+    distribution.data_files = get_data_files()
     # re-init build_py options which load package_data
     build_py.finalize_options()
 
@@ -163,23 +181,9 @@ setup(
     description="Jupyter widgets based on vuetify UI components",
     long_description=LONG_DESCRIPTION,
     include_package_data=True,
-    data_files=[
-        (
-            "share/jupyter/nbextensions/jupyter-vuetify",
-            glob.glob("ipyvuetify/nbextension/*"),
-        ),
-        (
-            "share/jupyter/labextensions/jupyter-vuetify",
-            glob.glob("ipyvuetify/labextension/package.json"),
-        ),
-        (
-            "share/jupyter/labextensions/jupyter-vuetify/static",
-            glob.glob("ipyvuetify/labextension/static/*"),
-        ),
-        ("etc/jupyter/nbconfig/notebook.d", ["jupyter-vuetify.json"]),
-    ],
-    install_requires = [
-        'ipyvue>=1.7,<2',
+    data_files=get_data_files(),
+    install_requires=[
+        "ipyvue>=1.7,<2",
     ],
     packages=find_packages(exclude=["generate_source"]),
     zip_safe=False,


### PR DESCRIPTION
We now triggered isolated builds, which means we do not have jupyterlab installed when we run the install command.

@12rambau I think this will solve the issue on RTD