### PR TITLE
build: install all hooks type at once

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_install_hook_types: [pre-commit, commit-msg]
+
 repos:
   - repo: "https://github.com/psf/black"
     rev: "22.3.0"


### PR DESCRIPTION
commitizen is a commit-msg hook, it won't be installed by default. Using the `default_install_hook_types` makes sure that all the hooks used in this file are installed when running:

```
pre-commit install
```

related to #257 