### PR TITLE
chore: use solara pytest plugin which is now released

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -185,12 +185,11 @@ setup(
     install_requires=[
         "ipyvue>=1.7,<2",
     ],
-    # we need to use the released version
-    # extras_require={
-    #     "test": [
-    #         "solara[pytest] @ https://github.com/widgetti/solara/archive/refs/heads/feat_test_ipywidgets.zip",
-    #     ]
-    # },
+    extras_require={
+        "test": [
+            "solara[pytest]",
+        ]
+    },
     packages=find_packages(exclude=["generate_source"]),
     zip_safe=False,
     cmdclass={


### PR DESCRIPTION
We could not release ipyvuetify with the pointer to a github branch.