### PR TITLE
refactor: delete never used requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,0 @@
-ipyvuetify>=1.2.2<2
-jupyter-sphinx==0.2.4a1
-sphinx_rtd_theme
-ipykernel

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,6 +17,5 @@ def lint(session):
 @nox.session(reuse_venv=True)
 def docs(session):
     """Build the documentation."""
-    session.install("jupyter-packaging", "jupyterlab")
     session.install(".[doc]")
     session.run("sphinx-build", "-v", "-b", "html", "docs", "docs/_build/html")


### PR DESCRIPTION
It is not used anywhere as the documentation is build on top of the `[doc]` extra-requirements