### PR TITLE
refactor: ignore import lint errors in __init__ files

### DIFF
--- a/ipyvuetify/__init__.py
+++ b/ipyvuetify/__init__.py
@@ -1,8 +1,8 @@
-from ._version import __version__ as __version__
+from ._version import __version__
 from .generated import *  # noqa: F403
-from .Html import Html as Html
-from .Themes import theme as theme
-from .VuetifyTemplate import VuetifyTemplate as VuetifyTemplate
+from .Html import Html
+from .Themes import theme
+from .VuetifyTemplate import VuetifyTemplate
 
 
 def _jupyter_labextension_paths():

--- a/ipyvuetify/__init__.py
+++ b/ipyvuetify/__init__.py
@@ -1,8 +1,8 @@
-from ._version import __version__  # noqa: F401
-from .generated import *  # noqa: F401, F403
-from .Html import Html  # noqa: F401
-from .Themes import theme  # noqa: F401
-from .VuetifyTemplate import VuetifyTemplate  # noqa: F401
+from ._version import __version__ as __version__
+from .generated import *  # noqa: F403
+from .Html import Html as Html
+from .Themes import theme as theme
+from .VuetifyTemplate import VuetifyTemplate as VuetifyTemplate
 
 
 def _jupyter_labextension_paths():

--- a/ipyvuetify/extra/__init__.py
+++ b/ipyvuetify/extra/__init__.py
@@ -1,1 +1,1 @@
-from .file_input import FileInput as FileInput
+from .file_input import FileInput

--- a/ipyvuetify/extra/__init__.py
+++ b/ipyvuetify/extra/__init__.py
@@ -1,1 +1,1 @@
-from .file_input import FileInput  # noqa: F401
+from .file_input import FileInput as FileInput

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,6 @@ ignore = [
 ]
 line-length = 100
 select = ["E", "W", "F", "Q", "I"]
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ exclude = ["docs*", "tests*"]
 universal = true
 
 [tool.ruff]
+ignore-init-module-imports = true
 fix = true
 exclude = [
     '.git',


### PR DESCRIPTION
ruff suggest to use dummy renaming in  `__init__` imports to avoid raising F401 error. the other solution is to add them to `__all__` but that's not an option as we use * for generated.