### PR TITLE
docs: use the vuetify colors in the docs

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -5,3 +5,12 @@
 div.jupyter_container.docutils {
   padding: 0.4em;
 }
+
+/* customize primary color to align with the vuetify website */
+html[data-theme="light"] {
+  --pst-color-primary: #1867c0;
+}
+
+html[data-theme="dark"] {
+  --pst-color-primary: #1697f6;
+}


### PR DESCRIPTION
everything is in the title, I used a color picker to use the 2 blues of vuetify documentation. Also because i'mnot a huge fan of the teal we use in pydata-sphinx-theme.