### PR TITLE
build: use file exist for js build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import sys
 from pathlib import Path
 
-from pynpm import NPMPackage
 from setuptools import Command, setup
 from setuptools.command.egg_info import egg_info
 
@@ -29,7 +28,9 @@ def js_prerelease(command: Command) -> None:
 
         def run(self):
             """Run the command"""
-            if sys.argv[1] == "sdist" or sys.argv[1] == "dist_info":
+            if not (ROOT / "prefix/share/jupyter/nbextensions/jupyter-vuetify/index.js").exists():
+                from pynpm import NPMPackage
+
                 from generate_source import generate_source
 
                 npm = NPMPackage(ROOT / "js" / "package.json")


### PR DESCRIPTION
Relying on the argv value doesn't work on conda-forge.

Also, only import pynpm when needed. On conda-forge it's not available which makes the build fail.