### PR TITLE
fix: revert css extraction

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -31,7 +31,6 @@
         "eslint-config-airbnb-base": "^13.1.0",
         "eslint-plugin-import": "^2.17.2",
         "eslint-plugin-vue": "^5.2.2",
-        "mini-css-extract-plugin": "^2.9.2",
         "npm-run-all": "^4.1.5",
         "postcss-loader": "^8.1.1",
         "postcss-scopify": "^1.0.0",

--- a/js/package.json
+++ b/js/package.json
@@ -47,7 +47,6 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.2",
     "eslint-plugin-vue": "^5.2.2",
-    "mini-css-extract-plugin": "^2.9.2",
     "npm-run-all": "^4.1.5",
     "postcss-loader": "^8.1.1",
     "postcss-scopify": "^1.0.0",

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -1,6 +1,5 @@
 var path = require("path");
 var version = require("./package.json").version;
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 // Custom webpack rules are generally the same for all webpack bundles, hence
 // stored in a separate local variable.
@@ -172,23 +171,8 @@ module.exports = [
     },
     devtool: "source-map",
     module: {
-      rules: [
-        {
-          test: /\.css$/,
-          use: [MiniCssExtractPlugin.loader, "css-loader", "postcss-loader"],
-        },
-        {
-          test: /\.(woff|woff2|eot|ttf|otf)$/,
-          type: "asset/resource",
-        },
-      ],
+      rules,
     },
-    // we extract the CSS to a separate file, since we might want to import it separately for global use
-    plugins: [
-      new MiniCssExtractPlugin({
-        filename: "jupyter-vuetify.min.css",
-      }),
-    ],
     externals: ["@jupyter-widgets/base", "@jupyterlab/apputils", "jupyter-vue"],
     resolve: {
       alias: {


### PR DESCRIPTION
https://github.com/widgetti/ipyvuetify/pull/327 broke embedded versions where the extractes CSS wasn't explicitly imported.